### PR TITLE
Add button to choose how the camera orientation is set

### DIFF
--- a/Comparisoft/QT/Comparisoft/mainwindow.cpp
+++ b/Comparisoft/QT/Comparisoft/mainwindow.cpp
@@ -120,13 +120,16 @@ void MainWindow::on_RunVTK_clicked()
     QLineEdit* target_attempt = findChild<QLineEdit*>("Target_Attempt");
     argv << target_attempt->text();
 
-    //argument 17: source file
+    //argument 17: Camera_Orientation
+    QComboBox* camera_orientation = findChild<QComboBox*>("camera_options");
+    argv << QString::number(camera_orientation->currentIndex());
+
+    //argument 18: source file
     QLineEdit* fileSource = findChild<QLineEdit*>("Source_File_Text");
     argv << fileSource->text();
 
-    //argument 18+: target file(s)
+    //argument 19+: target file(s)
     QTextEdit* fileTarget = findChild<QTextEdit*>("Target_File_Text");
-
 
     //insert multiple target files
     QString target_files = fileTarget->toPlainText();

--- a/Comparisoft/QT/Comparisoft/mainwindow.ui
+++ b/Comparisoft/QT/Comparisoft/mainwindow.ui
@@ -570,7 +570,7 @@
                 <item>
                  <widget class="QLabel" name="label_11">
                   <property name="text">
-                   <string>&lt;b&gt;Alignment type:&lt;/b&gt;</string>
+                   <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Alignment Type:&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                   </property>
                  </widget>
                 </item>
@@ -591,6 +591,33 @@
                    </widget>
                   </item>
                  </layout>
+                </item>
+                <item>
+                 <widget class="QLabel" name="label_17">
+                  <property name="font">
+                   <font>
+                    <weight>75</weight>
+                    <bold>true</bold>
+                   </font>
+                  </property>
+                  <property name="text">
+                   <string>Camera Orientation:</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QComboBox" name="camera_options">
+                  <item>
+                   <property name="text">
+                    <string>Matching Files</string>
+                   </property>
+                  </item>
+                  <item>
+                   <property name="text">
+                    <string>Fitting Files</string>
+                   </property>
+                  </item>
+                 </widget>
                 </item>
                </layout>
               </item>
@@ -745,7 +772,7 @@
      <x>0</x>
      <y>0</y>
      <width>1318</width>
-     <height>26</height>
+     <height>22</height>
     </rect>
    </property>
   </widget>

--- a/Comparisoft/VTK/VSVTK.cxx
+++ b/Comparisoft/VTK/VSVTK.cxx
@@ -209,6 +209,6 @@ int main(int argc, char *argv[])
 	report_output.close();
 
 	//Launch the VTK function
-	VTKmain(filePathSource, filePathTarget, screenshot, camera_orientation);
+	VTKmain(filePathSource, filePathTarget, filename, camera_orientation);
 
 }

--- a/Comparisoft/VTK/VSVTK.cxx
+++ b/Comparisoft/VTK/VSVTK.cxx
@@ -35,6 +35,7 @@ char* clevel = NULL;
 char* ebound = NULL;
 char* eunit = NULL;
 char* atype = NULL;
+char* camera_orientation = NULL;
 char* source_attempt = NULL;
 char* target_attempt = NULL;
 char* filePathSource = NULL;
@@ -152,15 +153,21 @@ int main(int argc, char *argv[])
 	cout << target_attempt;
 	cout << "\n";
 
-	//argument 17: source file
-	filePathSource = argv[17];
-	cout << "17: source file\n";
+	//argument 17: Camera_Orientation
+	camera_orientation = argv[17];
+	cout << "17: camera_orientation\n";
+	cout << camera_orientation;
+	cout << "\n";
+
+	//argument 18: source file
+	filePathSource = argv[18];
+	cout << "18: source file\n";
 	cout << filePathSource;
 	cout << "\n";
 
-	//argument 18+: target file(s)
-	filePathTarget = argv[18];
-	cout << "18: target file\n";
+	//argument 19+: target file(s)
+	filePathTarget = argv[19];
+	cout << "19: target file\n";
 	cout << filePathTarget;
 	cout << "\n";
 
@@ -202,6 +209,6 @@ int main(int argc, char *argv[])
 	report_output.close();
 
 	//Launch the VTK function
-	VTKmain(filePathSource, filePathTarget, screenshot);
+	VTKmain(filePathSource, filePathTarget, screenshot, camera_orientation);
 
 }

--- a/Comparisoft/VTK/VTK.cpp
+++ b/Comparisoft/VTK/VTK.cpp
@@ -26,7 +26,7 @@
 
 
 //VTK code goes here. It is now a function, and is called with the file paths.
-int VTKmain(char* filePathSource, char* filePathTarget, char* filename)
+int VTKmain(char* filePathSource, char* filePathTarget, char* filename, char *camera)
 {
 
 
@@ -133,9 +133,10 @@ int VTKmain(char* filePathSource, char* filePathTarget, char* filename)
     renderer3->SetViewport(comparison_pane);
     renderer3->ResetCamera();
 
-
-    //set the same camera for both renderers to ensure simultaneous interaction
-    renderer2->SetActiveCamera(renderer1->GetActiveCamera());
+    /* If the camera is set up for matching files, same camera for both renderers to ensure simultaneous interaction*/
+    if (strcmp(camera, "0") == 0) {
+        renderer2->SetActiveCamera(renderer1->GetActiveCamera());
+    }
 
     /* Create one render window and one interactor for each pane */
     vtkSmartPointer<vtkRenderWindow> renderWindow =

--- a/Comparisoft/VTK/VTK.h
+++ b/Comparisoft/VTK/VTK.h
@@ -3,4 +3,4 @@
 #include <string>
 
 std::string utf8_encode(const std::wstring &wstr);
-int VTKmain(char* filePathSource, char* filePathTarget, char* filename);
+int VTKmain(char* filePathSource, char* filePathTarget, char* filename, char *camera);


### PR DESCRIPTION
This includes a drop down menu on the Qt creator and the value of their choice being passed to VTK and the camera behaving accordingly.

Note: When "Fitting files" is selected (camera behaviour is one renderer at a time), only the file in which the user is selecting points can be rotated, not either one. Should be a future consideration to alter this.