### PR TITLE
added multiple keypress features

### DIFF
--- a/Comparisoft/VTK/PointSelection.cpp
+++ b/Comparisoft/VTK/PointSelection.cpp
@@ -250,9 +250,8 @@ void PointSelection::OnRightButtonDown()
 
 
 			is_completed=true;
-			if(is_completed){
-                source_count == 3;
-                target_count == 3;
+			if(is_completed && source_count == 3&&target_count == 3){
+
 				//change default renderer to renderer 3, such that renderer 3 can be accessed
 				vtkRendererCollection* panes = this->Interactor->GetRenderWindow()->GetRenderers();
 				vtkRenderer* nextRenderer = (vtkRenderer*)panes->GetItemAsObject(2);
@@ -377,15 +376,6 @@ void PointSelection:: OnKeyPress() {
             vtkRenderer* nextRenderer = (vtkRenderer*)panes->GetItemAsObject(1);
             this->SetDefaultRenderer(nextRenderer);
 
-
-            //change data into new renderer's data set
-            vtkActorCollection* actors = nextRenderer->GetActors();
-            vtkActor* Actor = (vtkActor*) actors->GetItemAsObject(0);
-            vtkDataSetMapper* mapper = (vtkDataSetMapper*)Actor->GetMapper();
-            vtkPolyData* triangleFilter2;
-            triangleFilter2 = dynamic_cast<vtkPolyData *>(mapper->GetInputAsDataSet());
-            Data=triangleFilter2;
-
             //remove pick
             std::cout << "Remove previous point " << count << std::endl;
 
@@ -407,35 +397,22 @@ void PointSelection:: OnKeyPress() {
         //3,2
         if(source_count=3&&target_count==2){
             //switch back to renderer 1
-            vtkRenderer* nextRenderer = this->Interactor->GetRenderWindow()->GetRenderers()->GetFirstRenderer();
-            this->SetDefaultRenderer(nextRenderer);
-
-
-            //change data into new renderer's data set
-            vtkActorCollection* actors = nextRenderer->GetActors();
-            vtkActor* Actor = (vtkActor*) actors->GetItemAsObject(0);
-            vtkDataSetMapper* mapper = (vtkDataSetMapper*)Actor->GetMapper();
-            vtkPolyData* triangleFilter1;
-            triangleFilter1 = dynamic_cast<vtkPolyData *>(mapper->GetInputAsDataSet());
-            Data=triangleFilter1;
-
             //remove pick
             std::cout << "Remove previous point " << count << std::endl;
             std::cout << "Actor size before removal "<< addedActors.size() << std::endl;
-            this->GetDefaultRenderer()->RemoveActor(addedActors.back());
+            this->Interactor->GetRenderWindow()->GetRenderers()->GetFirstRenderer()->RemoveActor(addedActors.back());
             addedActors.pop_back();
-            std::cout << "Actor size before removal "<< addedActors.size() << std::endl;
+            std::cout << "Actor size after removal "<< addedActors.size() << std::endl;
 
             std::cout << "Point " << count << " deleted " <<std::endl;
 
-            //clear previous storage
-            source_count--;
-            //target_count==2;
+            //clear previous storage resetting values
+            source_count++; //getting first renderer sets source and target count at 1 and 2 -> strange
             count --;
             std::cout << "current source number  " << source_count << std::endl;
             std::cout << "current target number  " << target_count << std::endl;
         }
-        //2,2
+        //2,2 
         if(source_count==2&&target_count==2){
             //switch back to renderer 2
             vtkRendererCollection* panes = this->Interactor->GetRenderWindow()->GetRenderers();
@@ -443,28 +420,17 @@ void PointSelection:: OnKeyPress() {
             this->SetDefaultRenderer(nextRenderer);
 
 
-            //change data into new renderer's data set
-            vtkActorCollection* actors = nextRenderer->GetActors();
-            vtkActor* Actor = (vtkActor*) actors->GetItemAsObject(0);
-            vtkDataSetMapper* mapper = (vtkDataSetMapper*)Actor->GetMapper();
-            vtkPolyData* triangleFilter2;
-            triangleFilter2 = dynamic_cast<vtkPolyData *>(mapper->GetInputAsDataSet());
-            Data=triangleFilter2;
-
             //remove pick
-            std::cout << "Remove previous point " << count << std::endl;
-
-            std::cout << addedActors.size() << std::endl;
-
+            std::cout << "Remove point " << count << std::endl;
             this->GetDefaultRenderer()->RemoveActor(addedActors.back());
             addedActors.pop_back();
-            std::cout << addedActors.size() << std::endl;
-            std::cout << "Re-pick point " << count << std::endl;
+            ;
+            std::cout << "Point" << count << " deleted" << std::endl;
 
 
-            source_count==2;
-            target_count==1;
-            count --;
+
+            target_count=1;
+            count--;
             std::cout << "current source number  " << source_count << std::endl;
             std::cout << "current target number  " << target_count << std::endl;
         }
@@ -475,22 +441,13 @@ void PointSelection:: OnKeyPress() {
             this->SetDefaultRenderer(nextRenderer);
 
 
-            //change data into new renderer's data set
-            vtkActorCollection* actors = nextRenderer->GetActors();
-            vtkActor* Actor = (vtkActor*) actors->GetItemAsObject(0);
-            vtkDataSetMapper* mapper = (vtkDataSetMapper*)Actor->GetMapper();
-            vtkPolyData* triangleFilter1;
-            triangleFilter1 = dynamic_cast<vtkPolyData *>(mapper->GetInputAsDataSet());
-            Data=triangleFilter1;
-
             //remove pick
-            std::cout << "Remove previous point " << count << std::endl;
-            std::cout << addedActors.size() << std::endl;
+            std::cout << "Remove point " << count << std::endl;
             this->GetDefaultRenderer()->RemoveActor(addedActors.back());
             addedActors.pop_back();
-            std::cout << addedActors.size() << std::endl;
 
-            std::cout << "Re-pick point " << count << std::endl;
+
+            std::cout << "Point " << count <<" deleted" << std::endl;
 
             source_count==1;
             target_count==1;
@@ -515,18 +472,14 @@ void PointSelection:: OnKeyPress() {
             Data=triangleFilter2;
 
             //remove pick
-            std::cout << "Remove previous point " << count << std::endl;
-
-            std::cout << addedActors.size() << std::endl;
-
+            std::cout << "Remove point " << count << std::endl;
             this->GetDefaultRenderer()->RemoveActor(addedActors.back());
             addedActors.pop_back();
-            std::cout << addedActors.size() << std::endl;
-            std::cout << "Re-pick point " << count << std::endl;
+
+            std::cout << "Point" << count << " deleted"<< std::endl;
 
 
-            source_count==1;
-            target_count==0;
+            target_count--;
             count --;
             std::cout << "current source number  " << source_count << std::endl;
             std::cout << "current target number  " << target_count << std::endl;
@@ -547,19 +500,18 @@ void PointSelection:: OnKeyPress() {
             Data=triangleFilter1;
 
             //remove pick
-            std::cout << "Remove previous point " << count << std::endl;
-            std::cout << addedActors.size() << std::endl;
+            std::cout << "Remove point " << count << std::endl;
             this->GetDefaultRenderer()->RemoveActor(addedActors.back());
             addedActors.pop_back();
-            std::cout << addedActors.size() << std::endl;
 
-            std::cout << "Re-pick point " << count << std::endl;
 
-            source_count==0;
-            target_count==0;
-            count==0;
+            std::cout << "Point"<< count <<" deleted " << std::endl;
+
+            source_count--;
+            count--;
             std::cout << "current source number  " << source_count << std::endl;
             std::cout << "current target number  " << target_count << std::endl;
+            std::cout << "reset count number:  "<< count << std::endl;
         }
 
 

--- a/Comparisoft/VTK/PointSelection.cpp
+++ b/Comparisoft/VTK/PointSelection.cpp
@@ -117,7 +117,7 @@ void PointSelection::OnRightButtonDown()
         addedActors.push_back(selectedActor);
 
 
-		if(count==1 || count == 3 || count== 5){
+		if((source_count == 0&&target_count == 0) || ( source_count == 1&&target_count == 1) || ( source_count == 2&&target_count == 2)){
 
 			this->GetDefaultRenderer()->AddActor(addedActors.back());
 			source_coordinates[source_count] = {picked[0], picked[1], picked[2]}; //stores source coordinates
@@ -131,7 +131,7 @@ void PointSelection::OnRightButtonDown()
 
 		}
 
-		else if(count== 2 || count == 4 || count ==6)
+		else if((source_count == 1&&target_count == 0) || ( source_count == 2&&target_count == 1) || (source_count == 3&&target_count == 2))
 		{
 			this->GetDefaultRenderer()->AddActor(addedActors.back());
 			target_coordinates[target_count] = {picked[0], picked[1], picked[2]};
@@ -179,7 +179,7 @@ void PointSelection::OnRightButtonDown()
 
 
 		//store picks after the end of selection
-		if(count==6 ){
+		if(count==6 && source_count == 3&&target_count == 3){
 			Align bottomPanel;
 			bottomPanel.filePathTarget 	= this->filePathTarget;
 			bottomPanel.filePathSource 	= this->filePathSource;
@@ -521,12 +521,14 @@ void PointSelection:: OnKeyPress() {
     if(key == "b")
     {
         keyBPressed = true;
-        std::cout << "The key 3 was pressed." << std::endl;
-        if(keyBPressed){
+
+        if(source_count==3&&target_count==3&& keyBPressed){
+            std::cout << "The key b was pressed." << std::endl;
             //change default renderer to renderer 3
             vtkRendererCollection* panes = this->Interactor->GetRenderWindow()->GetRenderers();
             vtkRenderer* nextRenderer = (vtkRenderer*)panes->GetItemAsObject(2);
             this->SetDefaultRenderer(nextRenderer);
+            keyBPressed = false;
 
 
         }
@@ -535,22 +537,27 @@ void PointSelection:: OnKeyPress() {
     if(key == "2")
     {
         key2Pressed = true;
-        std::cout << "The key 2 was pressed." << std::endl;
+
         if(key2Pressed){
-            //change default renderer to renderer 2
-            vtkRendererCollection* panes = this->Interactor->GetRenderWindow()->GetRenderers();
-            vtkRenderer* nextRenderer = (vtkRenderer*)panes->GetItemAsObject(1);
-            this->SetDefaultRenderer(nextRenderer);
+            if(source_count==3&&target_count==3){
+                std::cout << "The key 2 was pressed." << std::endl;
+
+                //change default renderer to renderer 2
+                vtkRendererCollection* panes = this->Interactor->GetRenderWindow()->GetRenderers();
+                vtkRenderer* nextRenderer = (vtkRenderer*)panes->GetItemAsObject(1);
+                this->SetDefaultRenderer(nextRenderer);
 
 
-            //change data into new renderer's data set
-            vtkActorCollection* actors = nextRenderer->GetActors();
-            vtkActor* Actor = (vtkActor*) actors->GetItemAsObject(0);
-            vtkDataSetMapper* mapper = (vtkDataSetMapper*)Actor->GetMapper();
-            vtkPolyData* triangleFilter2;
-            triangleFilter2 = dynamic_cast<vtkPolyData *>(mapper->GetInputAsDataSet());
-            Data=triangleFilter2;
-            key2Pressed = false;
+                //change data into new renderer's data set
+                vtkActorCollection* actors = nextRenderer->GetActors();
+                vtkActor* Actor = (vtkActor*) actors->GetItemAsObject(0);
+                vtkDataSetMapper* mapper = (vtkDataSetMapper*)Actor->GetMapper();
+                vtkPolyData* triangleFilter2;
+                triangleFilter2 = dynamic_cast<vtkPolyData *>(mapper->GetInputAsDataSet());
+                Data=triangleFilter2;
+                key2Pressed = false;
+            }
+
         }
     }
 
@@ -558,21 +565,26 @@ void PointSelection:: OnKeyPress() {
     if(key == "1")
     {
         key1Pressed = true;
-        std::cout << "The key 1 was pressed." << std::endl;
+
         if(key1Pressed){
-            //change default renderer to renderer 1
-            vtkRenderer* nextRenderer = this->Interactor->GetRenderWindow()->GetRenderers()->GetFirstRenderer();
-            this->SetDefaultRenderer(nextRenderer);
+            if(source_count==3&&target_count==3){
+                std::cout << "The key 1 was pressed." << std::endl;
+                //change default renderer to renderer 1
+                vtkRenderer* nextRenderer = this->Interactor->GetRenderWindow()->GetRenderers()->GetFirstRenderer();
+                this->SetDefaultRenderer(nextRenderer);
 
 
-            //change data into new renderer's data set
-            vtkActorCollection* actors = nextRenderer->GetActors();
-            vtkActor* Actor = (vtkActor*) actors->GetItemAsObject(0);
-            vtkDataSetMapper* mapper = (vtkDataSetMapper*)Actor->GetMapper();
-            vtkPolyData* triangleFilter1;
-            triangleFilter1 = dynamic_cast<vtkPolyData *>(mapper->GetInputAsDataSet());
-            Data=triangleFilter1;
-            key1Pressed = false;
+                //change data into new renderer's data set
+                vtkActorCollection* actors = nextRenderer->GetActors();
+                vtkActor* Actor = (vtkActor*) actors->GetItemAsObject(0);
+                vtkDataSetMapper* mapper = (vtkDataSetMapper*)Actor->GetMapper();
+                vtkPolyData* triangleFilter1;
+                triangleFilter1 = dynamic_cast<vtkPolyData *>(mapper->GetInputAsDataSet());
+                Data=triangleFilter1;
+                key1Pressed = false;
+            }
+
+
         }
     }
 

--- a/Comparisoft/VTK/PointSelection.cpp
+++ b/Comparisoft/VTK/PointSelection.cpp
@@ -395,7 +395,7 @@ void PointSelection:: OnKeyPress() {
             std::cout << "current target number  " << target_count << std::endl;
         }
         //3,2
-        if(source_count=3&&target_count==2){
+        if(source_count==3&&target_count==2){
             //switch back to renderer 1
             //remove pick
             std::cout << "Remove previous point " << count << std::endl;
@@ -412,7 +412,7 @@ void PointSelection:: OnKeyPress() {
             std::cout << "current source number  " << source_count << std::endl;
             std::cout << "current target number  " << target_count << std::endl;
         }
-        //2,2 
+        //2,2
         if(source_count==2&&target_count==2){
             //switch back to renderer 2
             vtkRendererCollection* panes = this->Interactor->GetRenderWindow()->GetRenderers();
@@ -435,7 +435,7 @@ void PointSelection:: OnKeyPress() {
             std::cout << "current target number  " << target_count << std::endl;
         }
         //2,1
-        if(source_count=2&&target_count==1){
+        if(source_count==2&&target_count==1){
             //switch back to renderer 1
             vtkRenderer* nextRenderer = this->Interactor->GetRenderWindow()->GetRenderers()->GetFirstRenderer();
             this->SetDefaultRenderer(nextRenderer);
@@ -449,8 +449,8 @@ void PointSelection:: OnKeyPress() {
 
             std::cout << "Point " << count <<" deleted" << std::endl;
 
-            source_count==1;
-            target_count==1;
+            source_count=1;
+            target_count=1;
             count --;
             std::cout << "current source number  " << source_count << std::endl;
             std::cout << "current target number  " << target_count << std::endl;
@@ -479,25 +479,17 @@ void PointSelection:: OnKeyPress() {
             std::cout << "Point" << count << " deleted"<< std::endl;
 
 
-            target_count--;
+            source_count=1;
+            target_count=0;
             count --;
             std::cout << "current source number  " << source_count << std::endl;
             std::cout << "current target number  " << target_count << std::endl;
         }
         //1,0
-        if(source_count=1&&target_count==0){
+        if(source_count==1&&target_count==0){
             //switch back to renderer 1
             vtkRenderer* nextRenderer = this->Interactor->GetRenderWindow()->GetRenderers()->GetFirstRenderer();
             this->SetDefaultRenderer(nextRenderer);
-
-
-            //change data into new renderer's data set
-            vtkActorCollection* actors = nextRenderer->GetActors();
-            vtkActor* Actor = (vtkActor*) actors->GetItemAsObject(0);
-            vtkDataSetMapper* mapper = (vtkDataSetMapper*)Actor->GetMapper();
-            vtkPolyData* triangleFilter1;
-            triangleFilter1 = dynamic_cast<vtkPolyData *>(mapper->GetInputAsDataSet());
-            Data=triangleFilter1;
 
             //remove pick
             std::cout << "Remove point " << count << std::endl;
@@ -507,8 +499,9 @@ void PointSelection:: OnKeyPress() {
 
             std::cout << "Point"<< count <<" deleted " << std::endl;
 
-            source_count--;
-            count--;
+            source_count=0;
+            target_count=0;
+            count=0;
             std::cout << "current source number  " << source_count << std::endl;
             std::cout << "current target number  " << target_count << std::endl;
             std::cout << "reset count number:  "<< count << std::endl;

--- a/Comparisoft/VTK/PointSelection.cpp
+++ b/Comparisoft/VTK/PointSelection.cpp
@@ -28,7 +28,7 @@ Adapted from: https://www.vtk.org/Wiki/VTK/Examples/Cxx/Interaction/PointPicker
 #include "vtkActor.h"
 
 char PointSelection::screenshot[100] = "";
-
+vtkRenderer* combinedPane;
 /**
 	@brief Alter the inherited OnLeftButtonDown() of
 	vtkInteractorStyleTrackballCamera to be compatible with our intended use.
@@ -187,7 +187,7 @@ void PointSelection::OnRightButtonDown()
 
 			//Get renderer for bottom viewpoint (it is the third renderer in the collection)
 			vtkRendererCollection* panes = this->Interactor->GetRenderWindow()->GetRenderers();
-			vtkRenderer* combinedPane = (vtkRenderer*)panes->GetItemAsObject(2);
+			combinedPane = (vtkRenderer*)panes->GetItemAsObject(2);
 
 			//Insert points into bottom panel
 			bottomPanel.sourcePoints = vtkSmartPointer<vtkPoints>::New();
@@ -388,10 +388,9 @@ void PointSelection:: OnKeyPress() {
             std::cout << "Point " << count <<" deleted " << std::endl;
 
 
-            //clear previous storage
-            //source_count==3;
-            target_count--;
-            count--;
+            source_count=3;
+            target_count=2;
+            count=5;
             std::cout << "current source number  " << source_count << std::endl;
             std::cout << "current target number  " << target_count << std::endl;
         }
@@ -407,9 +406,9 @@ void PointSelection:: OnKeyPress() {
 
             std::cout << "Point " << count << " deleted " <<std::endl;
 
-            //clear previous storage resetting values
-            source_count++; //getting first renderer sets source and target count at 1 and 2 -> strange
-            count --;
+            source_count=2;
+            target_count=2;
+            count=4;
             std::cout << "current source number  " << source_count << std::endl;
             std::cout << "current target number  " << target_count << std::endl;
         }
@@ -430,8 +429,9 @@ void PointSelection:: OnKeyPress() {
 
 
 
+            source_count=2;
             target_count=1;
-            count--;
+            count=3;
             std::cout << "current source number  " << source_count << std::endl;
             std::cout << "current target number  " << target_count << std::endl;
         }
@@ -452,7 +452,7 @@ void PointSelection:: OnKeyPress() {
 
             source_count=1;
             target_count=1;
-            count --;
+            count=2;
             std::cout << "current source number  " << source_count << std::endl;
             std::cout << "current target number  " << target_count << std::endl;
         }
@@ -464,14 +464,6 @@ void PointSelection:: OnKeyPress() {
             this->SetDefaultRenderer(nextRenderer);
 
 
-            //change data into new renderer's data set
-            vtkActorCollection* actors = nextRenderer->GetActors();
-            vtkActor* Actor = (vtkActor*) actors->GetItemAsObject(0);
-            vtkDataSetMapper* mapper = (vtkDataSetMapper*)Actor->GetMapper();
-            vtkPolyData* triangleFilter2;
-            triangleFilter2 = dynamic_cast<vtkPolyData *>(mapper->GetInputAsDataSet());
-            Data=triangleFilter2;
-
             //remove pick
             std::cout << "Remove point " << count << std::endl;
             this->GetDefaultRenderer()->RemoveActor(addedActors.back());
@@ -482,15 +474,29 @@ void PointSelection:: OnKeyPress() {
 
             source_count=1;
             target_count=0;
-            count --;
+            count=1;
             std::cout << "current source number  " << source_count << std::endl;
             std::cout << "current target number  " << target_count << std::endl;
         }
         //1,0
         if(source_count==1&&target_count==0){
-            //switch back to renderer 1
-            vtkRenderer* nextRenderer = this->Interactor->GetRenderWindow()->GetRenderers()->GetFirstRenderer();
+            //change default renderer to renderer 3
+            vtkRendererCollection* panes = this->Interactor->GetRenderWindow()->GetRenderers();
+            vtkRenderer* nextRenderer = (vtkRenderer*)panes->GetItemAsObject(2);
             this->SetDefaultRenderer(nextRenderer);
+            this->GetDefaultRenderer()->RemoveAllViewProps();
+
+            //switch back to renderer 1
+            nextRenderer = this->Interactor->GetRenderWindow()->GetRenderers()->GetFirstRenderer();
+            this->SetDefaultRenderer(nextRenderer);
+
+            //change data into new renderer's data set TO ALLOW FOR REPICK on renderer 1
+            vtkActorCollection* actors = nextRenderer->GetActors();
+            vtkActor* Actor = (vtkActor*) actors->GetItemAsObject(0);
+            vtkDataSetMapper* mapper = (vtkDataSetMapper*)Actor->GetMapper();
+            vtkPolyData* triangleFilter1;
+            triangleFilter1 = dynamic_cast<vtkPolyData *>(mapper->GetInputAsDataSet());
+            Data=triangleFilter1;
 
             //remove pick
             std::cout << "Remove point " << count << std::endl;
@@ -506,6 +512,7 @@ void PointSelection:: OnKeyPress() {
             std::cout << "current source number  " << source_count << std::endl;
             std::cout << "current target number  " << target_count << std::endl;
             std::cout << "reset count number:  "<< count << std::endl;
+
         }
 
 

--- a/Comparisoft/VTK/PointSelection.h
+++ b/Comparisoft/VTK/PointSelection.h
@@ -71,18 +71,22 @@ public:
 	/*Stores hightlighted data set*/
 	vtkSmartPointer<vtkDataSetMapper> selectedMapper; /*Stores hightlighted mapper*/
 	vtkSmartPointer<vtkActor> selectedActor; /*Stores hightlighted actor*/
-
+    vtkActor **array = new vtkActor* [6];
 
 	ofstream file;
 
 	bool is_open;
 	bool is_completed;
-    bool thirdPickConfirmed = false;
-    bool sixthPickConfirmed = false;
-    bool controlPressed;
-	void OnRightButtonDown() override ;
 
+
+    bool controlPressed;
+    bool zPressed;
+    bool key2Pressed, key1Pressed, keyBPressed;
+
+	void OnRightButtonDown() override ;
+    void OnKeyPress() override ;
 	static char screenshot[100];
+
 };
 
 #endif //VTK_POINTSELECTION_H

--- a/Comparisoft/VTK/PointSelection.h
+++ b/Comparisoft/VTK/PointSelection.h
@@ -71,8 +71,7 @@ public:
 	/*Stores hightlighted data set*/
 	vtkSmartPointer<vtkDataSetMapper> selectedMapper; /*Stores hightlighted mapper*/
 	vtkSmartPointer<vtkActor> selectedActor; /*Stores hightlighted actor*/
-    vtkActor **array = new vtkActor* [6];
-
+    std::vector<vtkSmartPointer<vtkActor> > addedActors;
 	ofstream file;
 
 	bool is_open;


### PR DESCRIPTION

- right click on renderer 1 (the initial default renderer) for 1st pick
- Press “2” to switch to renderer 2, right click to highlight on
renderer 2
- Press “1” to switch to renderer 1, right click to highlight on
renderer 1
- Press “b” to switch to render 3, right click to highlight on renderer
at the bottom [note “3” is not used as it is reserved by vtk]
- the use of hotkey "1", "2" allows user to pick points according to the industry standard by switching renderers before the alignment
- hotkeys "1", "2" and "b" can be used after the alignment for examination purposes

- Press “control + z” to remove previous pick, this works for 1st, 2nd,
3rd, 4th, 5th pick, not the 6th pick (for alignment purposes) [note control + z + right click is not longer required, only control + z is needed to remove the previous pick]

- Press “e” to exit the entire window and start over
[note remove all 6 points feature is not yet implemented, "e" could be an alternative solution if clearing all 6 points is difficult to implement]

@emersonk Hey, hopefully this could be good for use, let me know what you think of it, I believe there could be lots of improvement
@kseaman 
there's a limitation to having OnKeyPress method, please read the following
- left click on the renderer 1 is required for OnKeyPress method to
start listening for any key input [note : this step is essential for
switching renderers or any hotkey event]
